### PR TITLE
First version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "infinispan-rs"
+name = "infinispan"
 version = "0.1.0"
 authors = ["David Ortiz <z.david.ortiz@gmail.com>"]
 edition = "2018"
@@ -7,3 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+reqwest = "0.10.10"
+http = "0.2.3"
+base64 = "0.13.0"
+urlencoding = "1.1.1"
+serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,47 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+use std::convert::TryFrom;
+
+use reqwest::Response;
+
+use crate::request::Request;
+
+pub mod request;
+
+pub struct Infinispan {
+    base_url: String,
+    http_client: reqwest::Client,
+    basic_auth_encoded_val: String,
+}
+
+impl Infinispan {
+    pub fn new(
+        base_url: impl Into<String>,
+        username: impl AsRef<str>,
+        password: impl AsRef<str>,
+    ) -> Infinispan {
+        Infinispan {
+            base_url: base_url.into(),
+            http_client: reqwest::Client::new(),
+            basic_auth_encoded_val: Self::basic_auth_encoded_value(
+                username.as_ref(),
+                password.as_ref(),
+            ),
+        }
+    }
+
+    pub async fn run(&self, request: impl Into<Request>) -> Result<Response, reqwest::Error> {
+        let http_req = request
+            .into()
+            .to_http_req(&self.base_url, &self.basic_auth_encoded_val);
+
+        self.http_client
+            .execute(reqwest::Request::try_from(http_req).unwrap())
+            .await
+    }
+
+    fn basic_auth_encoded_value(username: &str, password: &str) -> String {
+        format!(
+            "Basic {}",
+            base64::encode(format!("{}:{}", username, password))
+        )
     }
 }

--- a/src/request/caches.rs
+++ b/src/request/caches.rs
@@ -1,0 +1,64 @@
+use crate::request::{Method, Request};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::HashMap;
+
+pub(crate) const CACHES_ENDPOINT: &str = "/rest/v2/caches";
+
+const DEFAULT_CONCURRENCY_LEVEL: i32 = 1000;
+const DEFAULT_ACQUIRE_TIMEOUT: i32 = 15000;
+
+#[derive(Serialize, Deserialize)]
+enum Cache {
+    #[serde(rename = "local-cache")]
+    LocalCache(LocalCache),
+}
+
+#[derive(Serialize, Deserialize)]
+struct LocalCache {
+    locking: Locking,
+    statistics: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Locking {
+    #[serde(rename = "concurrency-level")]
+    concurrency_level: i32,
+    #[serde(rename = "acquire-timeout")]
+    acquire_timeout: i32,
+    striping: bool,
+}
+
+impl Default for LocalCache {
+    fn default() -> Self {
+        LocalCache {
+            locking: Locking {
+                concurrency_level: DEFAULT_CONCURRENCY_LEVEL,
+                acquire_timeout: DEFAULT_ACQUIRE_TIMEOUT,
+                striping: false,
+            },
+            statistics: true,
+        }
+    }
+}
+
+pub fn create_local(name: impl AsRef<str>) -> Request {
+    Request::new(
+        Method::Post,
+        cache_url(name),
+        HashMap::new(),
+        Some(json!(Cache::LocalCache(LocalCache::default())).to_string()),
+    )
+}
+
+pub fn delete(name: impl AsRef<str>) -> Request {
+    Request::new(Method::Delete, cache_url(name), HashMap::new(), None)
+}
+
+fn cache_url(name: impl AsRef<str>) -> String {
+    format!(
+        "{caches_endpoint}/{cache_name}",
+        caches_endpoint = CACHES_ENDPOINT,
+        cache_name = urlencoding::encode(name.as_ref())
+    )
+}

--- a/src/request/counters.rs
+++ b/src/request/counters.rs
@@ -1,0 +1,159 @@
+use crate::request::{Method, Request};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::HashMap;
+
+const COUNTERS_ENDPOINT: &str = "/rest/v2/counters";
+
+type CounterVal = i64;
+
+#[derive(Debug, Serialize, Deserialize)]
+enum Counter {
+    #[serde(rename = "weak-counter")]
+    Weak(WeakCounter),
+    #[serde(rename = "strong-counter")]
+    Strong(StrongCounter),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct WeakCounter {
+    #[serde(rename = "initial-value", skip_serializing_if = "Option::is_none")]
+    initial_value: Option<CounterVal>,
+}
+
+impl WeakCounter {
+    pub fn set_value(&mut self, counter_val: CounterVal) {
+        self.initial_value = Some(counter_val);
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct StrongCounter {
+    #[serde(rename = "initial-value", skip_serializing_if = "Option::is_none")]
+    initial_value: Option<CounterVal>,
+}
+
+impl StrongCounter {
+    pub fn set_value(&mut self, counter_val: CounterVal) {
+        self.initial_value = Some(counter_val);
+    }
+}
+
+#[derive(Debug)]
+pub enum CounterType {
+    Weak,
+    Strong,
+}
+
+#[derive(Debug)]
+pub struct CreateCounterReq {
+    name: String,
+    counter: Counter,
+}
+
+impl CreateCounterReq {
+    pub fn new(name: impl Into<String>, counter_type: CounterType) -> CreateCounterReq {
+        let counter = match counter_type {
+            CounterType::Weak => Counter::Weak(WeakCounter {
+                initial_value: None,
+            }),
+            CounterType::Strong => Counter::Strong(StrongCounter {
+                initial_value: None,
+            }),
+        };
+
+        CreateCounterReq {
+            name: name.into(),
+            counter,
+        }
+    }
+
+    pub fn with_value(mut self, value: CounterVal) -> CreateCounterReq {
+        match &mut self.counter {
+            Counter::Weak(counter) => counter.set_value(value),
+            Counter::Strong(counter) => counter.set_value(value),
+        }
+
+        self
+    }
+}
+
+impl From<CreateCounterReq> for Request {
+    fn from(request: CreateCounterReq) -> Request {
+        Request::new(
+            Method::Post,
+            counter_path(request.name),
+            HashMap::new(),
+            Some(json!(request.counter).to_string()),
+        )
+    }
+}
+
+pub struct IncrementCounterReq {
+    name: String,
+    delta: Option<CounterVal>,
+}
+
+impl IncrementCounterReq {
+    pub fn new(name: impl Into<String>) -> IncrementCounterReq {
+        IncrementCounterReq {
+            name: name.into(),
+            delta: None,
+        }
+    }
+
+    pub fn by(mut self, delta: CounterVal) -> IncrementCounterReq {
+        self.delta = Some(delta);
+        self
+    }
+
+    fn query_with_args(&self) -> String {
+        match self.delta {
+            Some(delta) => {
+                format!("{}?action=add&delta={}", counter_path(&self.name), delta)
+            }
+            None => {
+                format!("{}?action=increment", counter_path(&self.name))
+            }
+        }
+    }
+}
+
+impl From<IncrementCounterReq> for Request {
+    fn from(request: IncrementCounterReq) -> Request {
+        Request::new(
+            Method::Post,
+            request.query_with_args(),
+            HashMap::new(),
+            None,
+        )
+    }
+}
+
+pub fn create_weak(name: impl Into<String>) -> CreateCounterReq {
+    CreateCounterReq::new(name, CounterType::Weak)
+}
+
+pub fn create_strong(name: impl Into<String>) -> CreateCounterReq {
+    CreateCounterReq::new(name, CounterType::Strong)
+}
+
+pub fn get(name: impl AsRef<str>) -> Request {
+    Request::new(Method::Get, counter_path(name), HashMap::new(), None)
+}
+
+pub fn increment(name: impl Into<String>) -> IncrementCounterReq {
+    IncrementCounterReq::new(name)
+}
+
+pub fn delete(name: impl AsRef<str>) -> Request {
+    Request::new(Method::Delete, counter_path(name), HashMap::new(), None)
+}
+
+fn counter_path(name: impl AsRef<str>) -> String {
+    format!(
+        "/{counters_endpoint}/{counter_name}",
+        counters_endpoint = COUNTERS_ENDPOINT,
+        counter_name = urlencoding::encode(name.as_ref())
+    )
+}

--- a/src/request/entries.rs
+++ b/src/request/entries.rs
@@ -1,0 +1,95 @@
+use crate::request::caches::CACHES_ENDPOINT;
+use crate::request::{Method, Request};
+use std::collections::HashMap;
+use std::time::Duration;
+
+const TTL_HEADER: &str = "timeToLiveSeconds";
+
+pub struct CreateEntryReq {
+    cache_name: String,
+    entry_name: String,
+    value: Option<String>,
+    ttl: Option<Duration>,
+}
+
+impl CreateEntryReq {
+    pub fn new(cache_name: impl Into<String>, entry_name: impl Into<String>) -> CreateEntryReq {
+        CreateEntryReq {
+            cache_name: cache_name.into(),
+            entry_name: entry_name.into(),
+            value: None,
+            ttl: None,
+        }
+    }
+
+    pub fn with_value(mut self, value: String) -> CreateEntryReq {
+        self.value = Some(value);
+        self
+    }
+
+    pub fn with_ttl(mut self, ttl: Duration) -> CreateEntryReq {
+        self.ttl = Some(ttl);
+        self
+    }
+}
+
+impl From<CreateEntryReq> for Request {
+    fn from(request: CreateEntryReq) -> Request {
+        let mut headers = HashMap::new();
+
+        if let Some(ttl) = request.ttl {
+            headers.insert(TTL_HEADER.into(), ttl.as_secs().to_string());
+        }
+
+        Request::new(
+            Method::Post,
+            entry_url(request.cache_name, request.entry_name),
+            headers,
+            request.value,
+        )
+    }
+}
+
+pub fn create(cache_name: impl Into<String>, entry_name: impl Into<String>) -> CreateEntryReq {
+    CreateEntryReq::new(cache_name, entry_name)
+}
+
+pub fn get(cache_name: impl AsRef<str>, entry_name: impl AsRef<str>) -> Request {
+    Request::new(
+        Method::Get,
+        entry_url(cache_name, entry_name),
+        HashMap::new(),
+        None,
+    )
+}
+
+pub fn update(
+    cache_name: impl AsRef<str>,
+    entry_name: impl AsRef<str>,
+    value: impl Into<String>,
+) -> Request {
+    Request::new(
+        Method::Put,
+        entry_url(cache_name, entry_name),
+        HashMap::new(),
+        Some(value.into()),
+    )
+}
+
+pub fn delete(cache_name: impl AsRef<str>, entry_name: impl AsRef<str>) -> Request {
+    Request::new(
+        Method::Delete,
+        entry_url(cache_name, entry_name),
+        HashMap::new(),
+        None,
+    )
+}
+
+fn entry_url(cache_name: impl AsRef<str>, entry_name: impl AsRef<str>) -> String {
+    format!(
+        "{caches_endpoint}/{cache_name}/{entry_name}",
+        caches_endpoint = CACHES_ENDPOINT,
+        cache_name = urlencoding::encode(cache_name.as_ref()),
+        entry_name = urlencoding::encode(entry_name.as_ref())
+    )
+}

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -1,0 +1,73 @@
+use std::collections::HashMap;
+
+use http::header::{AUTHORIZATION, CONTENT_TYPE};
+use http::Request as HttpRequest;
+
+pub mod caches;
+pub mod counters;
+pub mod entries;
+
+pub enum Method {
+    Get,
+    Post,
+    Put,
+    Delete,
+}
+
+impl Method {
+    pub fn as_str(&self) -> &str {
+        use Method::*;
+
+        match self {
+            Get => "GET",
+            Post => "POST",
+            Put => "PUT",
+            Delete => "DELETE",
+        }
+    }
+}
+
+pub struct Request {
+    pub method: Method,
+    pub path_and_query: String,
+    pub headers: HashMap<String, String>,
+    pub body: Option<String>,
+}
+
+impl Request {
+    pub fn new(
+        method: impl Into<Method>,
+        path_and_query: impl Into<String>,
+        headers: HashMap<String, String>,
+        body: Option<String>,
+    ) -> Request {
+        Request {
+            method: method.into(),
+            path_and_query: path_and_query.into(),
+            headers,
+            body,
+        }
+    }
+
+    pub fn to_http_req(
+        &self,
+        base_url: impl AsRef<str>,
+        basic_auth_encoded: impl AsRef<str>,
+    ) -> HttpRequest<String> {
+        let mut http_req = HttpRequest::builder()
+            .method(self.method.as_str())
+            .uri(format!("{}{}", base_url.as_ref(), self.path_and_query));
+
+        http_req = http_req
+            .header(CONTENT_TYPE, "application/json")
+            .header(AUTHORIZATION, basic_auth_encoded.as_ref());
+
+        for (header_name, header_val) in &self.headers {
+            http_req = http_req.header(header_name.as_str(), header_val);
+        }
+
+        http_req
+            .body(self.body.as_ref().map_or("".to_string(), |b| b.to_string()))
+            .unwrap()
+    }
+}


### PR DESCRIPTION
This PR is just a first version. It implements a very reduced subset of what Infinispan offers, but enough to use it from [Limitador](https://github.com/3scale-labs/limitador) and pass its integration tests.

More specifically, this PR implements some parts of the [REST API](https://infinispan.org/docs/stable/titles/rest/rest.html) for `Counters`, `Caches`, and `Entries`.

The PR it's missing integration tests and docs. The part that helps parse the API responses is missing too. I wanted to agree on the basics before moving forward.