### PR TITLE
Integration tests: Caches

### DIFF
--- a/src/request/caches.rs
+++ b/src/request/caches.rs
@@ -51,6 +51,10 @@ pub fn create_local(name: impl AsRef<str>) -> Request {
     )
 }
 
+pub fn exists(name: impl AsRef<str>) -> Request {
+    Request::new(Method::Head, cache_url(name), HashMap::new(), None)
+}
+
 pub fn delete(name: impl AsRef<str>) -> Request {
     Request::new(Method::Delete, cache_url(name), HashMap::new(), None)
 }

--- a/tests/caches.rs
+++ b/tests/caches.rs
@@ -1,0 +1,33 @@
+mod helpers;
+
+#[cfg(test)]
+mod caches {
+    use crate::helpers::*;
+    use http::StatusCode;
+    use infinispan::request::caches;
+    use serial_test::serial;
+
+    #[tokio::test]
+    #[serial]
+    async fn create_local() {
+        let cache_name = "test_cache";
+
+        let _ = run(caches::create_local(cache_name)).await;
+        let resp = run(caches::exists(cache_name)).await;
+
+        assert!(resp.status().is_success());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn delete() {
+        let cache_name = "test_cache";
+
+        let _ = run(caches::create_local(cache_name)).await;
+
+        let _ = run(caches::delete(cache_name)).await;
+        let resp = run(caches::exists(cache_name)).await;
+
+        assert_eq!(StatusCode::NOT_FOUND, resp.status());
+    }
+}


### PR DESCRIPTION
~Includes some commits from #4  (because it needs the changes in `Request`), so #4 needs to be merged first.~

The tests included in this PR are very simple, that's because the `Cache` struct right now is a very simplified version of what's supported in Infinispan and will need to change for sure.