### PR TITLE
Take a reference in Client.run() so requests can be reused

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 
 use reqwest::Response;
 
-use crate::request::Request;
+use crate::request::ToHttpRequest;
 
 pub mod request;
 
@@ -28,10 +28,8 @@ impl Infinispan {
         }
     }
 
-    pub async fn run(&self, request: impl Into<Request>) -> Result<Response, reqwest::Error> {
-        let http_req = request
-            .into()
-            .to_http_req(&self.base_url, &self.basic_auth_encoded_val);
+    pub async fn run<R: ToHttpRequest>(&self, request: &R) -> Result<Response, reqwest::Error> {
+        let http_req = request.to_http_req(&self.base_url, &self.basic_auth_encoded_val);
 
         self.http_client
             .execute(reqwest::Request::try_from(http_req).unwrap())

--- a/src/request/counters.rs
+++ b/src/request/counters.rs
@@ -1,4 +1,4 @@
-use crate::request::{Method, Request};
+use crate::request::{Method, Request, ToHttpRequest};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::HashMap;
@@ -78,14 +78,24 @@ impl CreateCounterReq {
     }
 }
 
-impl From<CreateCounterReq> for Request {
-    fn from(request: CreateCounterReq) -> Request {
+impl From<&CreateCounterReq> for Request {
+    fn from(request: &CreateCounterReq) -> Request {
         Request::new(
             Method::Post,
-            counter_path(request.name),
+            counter_path(&request.name),
             HashMap::new(),
             Some(json!(request.counter).to_string()),
         )
+    }
+}
+
+impl ToHttpRequest for CreateCounterReq {
+    fn to_http_req(
+        &self,
+        base_url: impl AsRef<str>,
+        basic_auth_encoded: impl AsRef<str>,
+    ) -> http::Request<String> {
+        Request::from(self).to_http_req(base_url, basic_auth_encoded)
     }
 }
 
@@ -119,14 +129,24 @@ impl IncrementCounterReq {
     }
 }
 
-impl From<IncrementCounterReq> for Request {
-    fn from(request: IncrementCounterReq) -> Request {
+impl From<&IncrementCounterReq> for Request {
+    fn from(request: &IncrementCounterReq) -> Request {
         Request::new(
             Method::Post,
             request.query_with_args(),
             HashMap::new(),
             None,
         )
+    }
+}
+
+impl ToHttpRequest for IncrementCounterReq {
+    fn to_http_req(
+        &self,
+        base_url: impl AsRef<str>,
+        basic_auth_encoded: impl AsRef<str>,
+    ) -> http::Request<String> {
+        Request::from(self).to_http_req(base_url, basic_auth_encoded)
     }
 }
 

--- a/src/request/entries.rs
+++ b/src/request/entries.rs
@@ -1,5 +1,5 @@
 use crate::request::caches::CACHES_ENDPOINT;
-use crate::request::{Method, Request};
+use crate::request::{Method, Request, ToHttpRequest};
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -33,8 +33,8 @@ impl CreateEntryReq {
     }
 }
 
-impl From<CreateEntryReq> for Request {
-    fn from(request: CreateEntryReq) -> Request {
+impl From<&CreateEntryReq> for Request {
+    fn from(request: &CreateEntryReq) -> Request {
         let mut headers = HashMap::new();
 
         if let Some(ttl) = request.ttl {
@@ -43,10 +43,20 @@ impl From<CreateEntryReq> for Request {
 
         Request::new(
             Method::Post,
-            entry_url(request.cache_name, request.entry_name),
+            entry_url(&request.cache_name, &request.entry_name),
             headers,
-            request.value,
+            request.value.clone(),
         )
+    }
+}
+
+impl ToHttpRequest for CreateEntryReq {
+    fn to_http_req(
+        &self,
+        base_url: impl AsRef<str>,
+        basic_auth_encoded: impl AsRef<str>,
+    ) -> http::Request<String> {
+        Request::from(self).to_http_req(base_url, basic_auth_encoded)
     }
 }
 

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -36,6 +36,14 @@ pub struct Request {
     pub body: Option<String>,
 }
 
+pub trait ToHttpRequest {
+    fn to_http_req(
+        &self,
+        base_url: impl AsRef<str>,
+        basic_auth_encoded: impl AsRef<str>,
+    ) -> HttpRequest<String>;
+}
+
 impl Request {
     pub fn new(
         method: impl Into<Method>,
@@ -50,8 +58,10 @@ impl Request {
             body,
         }
     }
+}
 
-    pub fn to_http_req(
+impl ToHttpRequest for Request {
+    fn to_http_req(
         &self,
         base_url: impl AsRef<str>,
         basic_auth_encoded: impl AsRef<str>,

--- a/tests/caches.rs
+++ b/tests/caches.rs
@@ -12,8 +12,8 @@ mod caches {
     async fn create_local() {
         let cache_name = "test_cache";
 
-        let _ = run(caches::create_local(cache_name)).await;
-        let resp = run(caches::exists(cache_name)).await;
+        let _ = run(&caches::create_local(cache_name)).await;
+        let resp = run(&caches::exists(cache_name)).await;
 
         assert!(resp.status().is_success());
     }
@@ -23,10 +23,10 @@ mod caches {
     async fn delete() {
         let cache_name = "test_cache";
 
-        let _ = run(caches::create_local(cache_name)).await;
+        let _ = run(&caches::create_local(cache_name)).await;
 
-        let _ = run(caches::delete(cache_name)).await;
-        let resp = run(caches::exists(cache_name)).await;
+        let _ = run(&caches::delete(cache_name)).await;
+        let resp = run(&caches::exists(cache_name)).await;
 
         assert_eq!(StatusCode::NOT_FOUND, resp.status());
     }

--- a/tests/counters.rs
+++ b/tests/counters.rs
@@ -20,8 +20,8 @@ mod counters {
 
         let counter_name = "test_counter";
 
-        let _ = run(counters::create_weak(counter_name)).await;
-        let resp = run(counters::get(counter_name)).await;
+        let _ = run(&counters::create_weak(counter_name)).await;
+        let resp = run(&counters::get(counter_name)).await;
 
         assert!(resp.status().is_success());
         assert_eq!("0", resp.bytes().await.unwrap()); // Default counter value is 0
@@ -35,8 +35,8 @@ mod counters {
         let counter_name = "test_counter";
         let counter_val = 10;
 
-        let _ = run(counters::create_weak(counter_name).with_value(counter_val)).await;
-        let resp = run(counters::get(counter_name)).await;
+        let _ = run(&counters::create_weak(counter_name).with_value(counter_val)).await;
+        let resp = run(&counters::get(counter_name)).await;
 
         assert!(resp.status().is_success());
         assert_eq!(counter_val.to_string(), resp.bytes().await.unwrap());
@@ -49,8 +49,8 @@ mod counters {
 
         let counter_name = "test_counter";
 
-        let _ = run(counters::create_strong(counter_name)).await;
-        let resp = run(counters::get(counter_name)).await;
+        let _ = run(&counters::create_strong(counter_name)).await;
+        let resp = run(&counters::get(counter_name)).await;
 
         assert!(resp.status().is_success());
         assert_eq!("0", resp.bytes().await.unwrap()); // Default counter value is 0
@@ -64,8 +64,8 @@ mod counters {
         let counter_name = "test_counter";
         let counter_val = 10;
 
-        let _ = run(counters::create_strong(counter_name).with_value(counter_val)).await;
-        let resp = run(counters::get(counter_name)).await;
+        let _ = run(&counters::create_strong(counter_name).with_value(counter_val)).await;
+        let resp = run(&counters::get(counter_name)).await;
 
         assert!(resp.status().is_success());
         assert_eq!(counter_val.to_string(), resp.bytes().await.unwrap());
@@ -78,9 +78,9 @@ mod counters {
 
         let counter_name = "test_counter";
 
-        let _ = run(counters::create_strong(counter_name)).await;
-        let _ = run(counters::increment(counter_name)).await;
-        let resp = run(counters::get(counter_name)).await;
+        let _ = run(&counters::create_strong(counter_name)).await;
+        let _ = run(&counters::increment(counter_name)).await;
+        let resp = run(&counters::get(counter_name)).await;
 
         assert!(resp.status().is_success());
         assert_eq!("1", resp.bytes().await.unwrap());
@@ -93,9 +93,9 @@ mod counters {
 
         let counter_name = "test_counter";
 
-        let _ = run(counters::create_strong(counter_name).with_value(1)).await;
-        let _ = run(counters::increment(counter_name).by(2)).await;
-        let resp = run(counters::get(counter_name)).await;
+        let _ = run(&counters::create_strong(counter_name).with_value(1)).await;
+        let _ = run(&counters::increment(counter_name).by(2)).await;
+        let resp = run(&counters::get(counter_name)).await;
 
         assert!(resp.status().is_success());
         assert_eq!("3", resp.bytes().await.unwrap());
@@ -108,9 +108,9 @@ mod counters {
 
         let counter_name = "test_counter";
 
-        let _ = run(counters::create_weak(counter_name)).await;
-        let _ = run(counters::delete(counter_name)).await;
-        let resp = run(counters::get(counter_name)).await;
+        let _ = run(&counters::create_weak(counter_name)).await;
+        let _ = run(&counters::delete(counter_name)).await;
+        let resp = run(&counters::get(counter_name)).await;
 
         assert_eq!(StatusCode::NOT_FOUND, resp.status());
     }
@@ -124,19 +124,19 @@ mod counters {
             HashSet::from_iter(vec!["counter_1".into(), "counter_2".into()]);
 
         for counter_name in &counter_names {
-            let _ = run(counters::create_weak(counter_name)).await;
+            let _ = run(&counters::create_weak(counter_name)).await;
         }
 
-        let resp = run(counters::list()).await;
+        let resp = run(&counters::list()).await;
 
         assert_eq!(counter_names, counter_names_from_list_resp(resp).await);
     }
 
     async fn cleanup() {
-        let resp = run(counters::list()).await;
+        let resp = run(&counters::list()).await;
 
         for counter_name in counter_names_from_list_resp(resp).await {
-            let _ = run(counters::delete(counter_name)).await;
+            let _ = run(&counters::delete(counter_name)).await;
         }
     }
 

--- a/tests/entries.rs
+++ b/tests/entries.rs
@@ -18,8 +18,8 @@ mod entries {
 
         let entry_name = "test_entry";
 
-        let _ = run(entries::create(TEST_CACHE_NAME, entry_name)).await;
-        let resp = run(entries::exists(TEST_CACHE_NAME, entry_name)).await;
+        let _ = run(&entries::create(TEST_CACHE_NAME, entry_name)).await;
+        let resp = run(&entries::exists(TEST_CACHE_NAME, entry_name)).await;
 
         assert!(resp.status().is_success());
     }
@@ -33,8 +33,8 @@ mod entries {
         let entry_value = "some_value";
 
         let _ =
-            run(entries::create(TEST_CACHE_NAME, entry_name).with_value(entry_value.into())).await;
-        let resp = run(entries::get(TEST_CACHE_NAME, entry_name)).await;
+            run(&entries::create(TEST_CACHE_NAME, entry_name).with_value(entry_value.into())).await;
+        let resp = run(&entries::get(TEST_CACHE_NAME, entry_name)).await;
 
         assert_eq!(entry_value, entry_value_from_resp(resp).await);
     }
@@ -47,10 +47,10 @@ mod entries {
         let existing_key_name = "existing";
         let non_existing_key_name = "non_existing";
 
-        let _ = run(entries::create(TEST_CACHE_NAME, existing_key_name)).await;
+        let _ = run(&entries::create(TEST_CACHE_NAME, existing_key_name)).await;
 
-        let resp_existing = run(entries::exists(TEST_CACHE_NAME, existing_key_name)).await;
-        let resp_non_existing = run(entries::exists(TEST_CACHE_NAME, non_existing_key_name)).await;
+        let resp_existing = run(&entries::exists(TEST_CACHE_NAME, existing_key_name)).await;
+        let resp_non_existing = run(&entries::exists(TEST_CACHE_NAME, non_existing_key_name)).await;
 
         assert!(resp_existing.status().is_success());
         assert_eq!(StatusCode::NOT_FOUND, resp_non_existing.status());
@@ -65,12 +65,12 @@ mod entries {
         let new_value = "new_value";
 
         let _ =
-            run(entries::create(TEST_CACHE_NAME, entry_name)
+            run(&entries::create(TEST_CACHE_NAME, entry_name)
                 .with_value("some_initial_value".into()))
             .await;
 
-        let _ = run(entries::update(TEST_CACHE_NAME, entry_name, new_value)).await;
-        let resp = run(entries::get(TEST_CACHE_NAME, entry_name)).await;
+        let _ = run(&entries::update(TEST_CACHE_NAME, entry_name, new_value)).await;
+        let resp = run(&entries::get(TEST_CACHE_NAME, entry_name)).await;
 
         assert_eq!(new_value, entry_value_from_resp(resp).await);
     }
@@ -82,18 +82,18 @@ mod entries {
 
         let entry_name = "test_entry";
 
-        let _ = run(entries::create(TEST_CACHE_NAME, entry_name)).await;
-        let resp = run(entries::exists(TEST_CACHE_NAME, entry_name)).await;
+        let _ = run(&entries::create(TEST_CACHE_NAME, entry_name)).await;
+        let resp = run(&entries::exists(TEST_CACHE_NAME, entry_name)).await;
         assert!(resp.status().is_success());
 
-        let _ = run(entries::delete(TEST_CACHE_NAME, entry_name)).await;
-        let resp = run(entries::exists(TEST_CACHE_NAME, entry_name)).await;
+        let _ = run(&entries::delete(TEST_CACHE_NAME, entry_name)).await;
+        let resp = run(&entries::exists(TEST_CACHE_NAME, entry_name)).await;
         assert_eq!(StatusCode::NOT_FOUND, resp.status());
     }
 
     async fn setup() {
-        let _ = run(caches::delete(TEST_CACHE_NAME)).await;
-        let _ = run(caches::create_local(TEST_CACHE_NAME)).await;
+        let _ = run(&caches::delete(TEST_CACHE_NAME)).await;
+        let _ = run(&caches::create_local(TEST_CACHE_NAME)).await;
     }
 
     async fn entry_value_from_resp(response: Response) -> String {

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -1,4 +1,4 @@
-use infinispan::request::Request;
+use infinispan::request::ToHttpRequest;
 use infinispan::Infinispan;
 use reqwest::Response;
 
@@ -6,6 +6,6 @@ pub fn infinispan_client() -> Infinispan {
     Infinispan::new("http://localhost:11222", "username", "password")
 }
 
-pub async fn run(request: impl Into<Request>) -> Response {
+pub async fn run<R: ToHttpRequest>(request: &R) -> Response {
     infinispan_client().run(request).await.unwrap()
 }


### PR DESCRIPTION
This PR changes `Client.run` so it takes a reference. This allows us to reuse requests instead of having to instantiate a new one every time we need to make a call to Infinispan.

The `run` function now takes a reference to something that implements the trait `ToHttpRequest`, introduced in this PR as well.