### PR TITLE
Add basic error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ base64 = "0.13.0"
 urlencoding = "1.1.1"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0"
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["rt-core", "macros"] }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum InfinispanError {
+    #[error("error while sending the request to Infinispan")]
+    Connection(#[from] reqwest::Error),
+}


### PR DESCRIPTION
This PR adds some basic error handling based on the `thiserror` crate.
For now, the intention is to create a custom error type (`InfinispanError`) and expose that to the user of the lib instead of errors of other libraries. 