### PR TITLE
Add missing operations for "Cache"

### DIFF
--- a/src/request/caches.rs
+++ b/src/request/caches.rs
@@ -42,6 +42,23 @@ impl Default for LocalCache {
     }
 }
 
+#[derive(Debug)]
+enum Action {
+    Clear,
+    Config,
+    Keys,
+    Size,
+    Stats,
+}
+
+impl Action {
+    pub fn to_query_args(&self) -> String {
+        let mut query_args = format!("action={:?}", self);
+        query_args.make_ascii_lowercase();
+        query_args
+    }
+}
+
 pub fn create_local(name: impl AsRef<str>) -> Request {
     Request::new(
         Method::Post,
@@ -55,8 +72,61 @@ pub fn exists(name: impl AsRef<str>) -> Request {
     Request::new(Method::Head, cache_url(name), HashMap::new(), None)
 }
 
+pub fn get(name: impl AsRef<str>) -> Request {
+    Request::new(Method::Get, cache_url(name), HashMap::new(), None)
+}
+
+pub fn get_config(name: impl AsRef<str>) -> Request {
+    Request::new(
+        Method::Get,
+        cache_url_with_action(name, &Action::Config),
+        HashMap::new(),
+        None,
+    )
+}
+
 pub fn delete(name: impl AsRef<str>) -> Request {
     Request::new(Method::Delete, cache_url(name), HashMap::new(), None)
+}
+
+pub fn keys(name: impl AsRef<str>) -> Request {
+    Request::new(
+        Method::Get,
+        cache_url_with_action(name, &Action::Keys),
+        HashMap::new(),
+        None,
+    )
+}
+
+pub fn clear(name: impl AsRef<str>) -> Request {
+    Request::new(
+        Method::Post,
+        cache_url_with_action(name, &Action::Clear),
+        HashMap::new(),
+        None,
+    )
+}
+
+pub fn size(name: impl AsRef<str>) -> Request {
+    Request::new(
+        Method::Get,
+        cache_url_with_action(name, &Action::Size),
+        HashMap::new(),
+        None,
+    )
+}
+
+pub fn stats(name: impl AsRef<str>) -> Request {
+    Request::new(
+        Method::Get,
+        cache_url_with_action(name, &Action::Stats),
+        HashMap::new(),
+        None,
+    )
+}
+
+pub fn list() -> Request {
+    Request::new(Method::Get, CACHES_ENDPOINT, HashMap::new(), None)
 }
 
 fn cache_url(name: impl AsRef<str>) -> String {
@@ -65,4 +135,8 @@ fn cache_url(name: impl AsRef<str>) -> String {
         caches_endpoint = CACHES_ENDPOINT,
         cache_name = urlencoding::encode(name.as_ref())
     )
+}
+
+fn cache_url_with_action(name: impl AsRef<str>, action: &Action) -> String {
+    format!("{}?{}", cache_url(name), action.to_query_args())
 }

--- a/tests/caches.rs
+++ b/tests/caches.rs
@@ -4,12 +4,18 @@ mod helpers;
 mod caches {
     use crate::helpers::*;
     use http::StatusCode;
-    use infinispan::request::caches;
+    use infinispan::request::{caches, entries};
+    use reqwest::Response;
+    use serde_json::Value;
     use serial_test::serial;
+    use std::collections::HashSet;
+    use std::iter::FromIterator;
 
     #[tokio::test]
     #[serial]
     async fn create_local() {
+        cleanup().await;
+
         let cache_name = "test_cache";
 
         let _ = run(&caches::create_local(cache_name)).await;
@@ -20,7 +26,42 @@ mod caches {
 
     #[tokio::test]
     #[serial]
+    async fn get() {
+        cleanup().await;
+
+        let cache_name = "test_cache";
+
+        let _ = run(&caches::create_local(cache_name)).await;
+
+        let resp = run(&caches::get(cache_name)).await;
+        let info: Value = serde_json::from_str(&read_body(resp).await).unwrap();
+
+        // Basic checks
+        assert!(!info["stats"].is_null());
+        assert!(!info["configuration"].is_null());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn get_config() {
+        cleanup().await;
+
+        let cache_name = "test_cache";
+
+        let _ = run(&caches::create_local(cache_name)).await;
+
+        let resp = run(&caches::get_config(cache_name)).await;
+        let config: Value = serde_json::from_str(&read_body(resp).await).unwrap();
+
+        // Basic check
+        assert!(!config["local-cache"].is_null());
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn delete() {
+        cleanup().await;
+
         let cache_name = "test_cache";
 
         let _ = run(&caches::create_local(cache_name)).await;
@@ -29,5 +70,107 @@ mod caches {
         let resp = run(&caches::exists(cache_name)).await;
 
         assert_eq!(StatusCode::NOT_FOUND, resp.status());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn get_keys() {
+        cleanup().await;
+
+        let cache_name = "test_cache";
+        let keys: HashSet<String> = HashSet::from_iter(vec!["k1".into(), "k2".into()]);
+
+        let _ = run(&caches::create_local(cache_name)).await;
+
+        for key in &keys {
+            let _ = run(&entries::create(cache_name, key)).await;
+        }
+
+        let resp = run(&caches::keys(cache_name)).await;
+
+        assert_eq!(keys, serde_json::from_str(&read_body(resp).await).unwrap())
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn clear() {
+        cleanup().await;
+
+        let cache_name = "test_cache";
+
+        let _ = run(&caches::create_local(cache_name)).await;
+        let _ = run(&entries::create(cache_name, "some_entry")).await;
+
+        let _ = run(&caches::clear(cache_name)).await;
+        let resp = run(&caches::size(cache_name)).await;
+
+        assert_eq!("0", read_body(resp).await);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn size() {
+        cleanup().await;
+
+        let cache_name = "test_cache";
+
+        let _ = run(&caches::create_local(cache_name)).await;
+
+        let resp = run(&caches::size(cache_name)).await;
+        assert_eq!("0", read_body(resp).await);
+
+        let _ = run(&entries::create(cache_name, "some_entry")).await;
+        let resp = run(&caches::size(cache_name)).await;
+        assert_eq!("1", read_body(resp).await);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn stats() {
+        cleanup().await;
+
+        let cache_name = "test_cache";
+
+        let _ = run(&caches::create_local(cache_name)).await;
+
+        let resp = run(&caches::stats(cache_name)).await;
+        let config: Value = serde_json::from_str(&read_body(resp).await).unwrap();
+
+        // Basic check
+        assert!(!config["time_since_start"].is_null());
+        assert!(!config["time_since_reset"].is_null());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn list() {
+        cleanup().await;
+
+        let cache_names: HashSet<String> =
+            HashSet::from_iter(vec!["cache_1".into(), "cache_2".into()]);
+
+        for cache_name in &cache_names {
+            let _ = run(&caches::create_local(cache_name)).await;
+        }
+
+        let resp = run(&caches::list()).await;
+
+        assert_eq!(cache_names, cache_names_from_list_resp(resp).await);
+    }
+
+    async fn cleanup() {
+        let resp = run(&caches::list()).await;
+
+        for counter_name in cache_names_from_list_resp(resp).await {
+            let _ = run(&caches::delete(counter_name)).await;
+        }
+    }
+
+    async fn cache_names_from_list_resp(response: Response) -> HashSet<String> {
+        serde_json::from_str(&read_body(response).await).unwrap()
+    }
+
+    async fn read_body(response: Response) -> String {
+        response.text_with_charset("utf-8").await.unwrap()
     }
 }

--- a/tests/caches.rs
+++ b/tests/caches.rs
@@ -169,8 +169,4 @@ mod caches {
     async fn cache_names_from_list_resp(response: Response) -> HashSet<String> {
         serde_json::from_str(&read_body(response).await).unwrap()
     }
-
-    async fn read_body(response: Response) -> String {
-        response.text_with_charset("utf-8").await.unwrap()
-    }
 }

--- a/tests/counters.rs
+++ b/tests/counters.rs
@@ -25,7 +25,7 @@ mod counters {
         let resp = run(&counters::get(counter_name)).await;
 
         assert!(resp.status().is_success());
-        assert_eq!("0", resp.bytes().await.unwrap()); // Default counter value is 0
+        assert_eq!("0", read_body(resp).await); // Default counter value is 0
     }
 
     #[tokio::test]
@@ -40,7 +40,7 @@ mod counters {
         let resp = run(&counters::get(counter_name)).await;
 
         assert!(resp.status().is_success());
-        assert_eq!(counter_val.to_string(), resp.bytes().await.unwrap());
+        assert_eq!(counter_val.to_string(), read_body(resp).await);
     }
 
     #[tokio::test]
@@ -54,7 +54,7 @@ mod counters {
         let resp = run(&counters::get(counter_name)).await;
 
         assert!(resp.status().is_success());
-        assert_eq!("0", resp.bytes().await.unwrap()); // Default counter value is 0
+        assert_eq!("0", read_body(resp).await); // Default counter value is 0
     }
 
     #[tokio::test]
@@ -69,7 +69,7 @@ mod counters {
         let resp = run(&counters::get(counter_name)).await;
 
         assert!(resp.status().is_success());
-        assert_eq!(counter_val.to_string(), resp.bytes().await.unwrap());
+        assert_eq!(counter_val.to_string(), read_body(resp).await);
     }
 
     #[tokio::test]
@@ -85,9 +85,7 @@ mod counters {
 
         assert!(resp.status().is_success());
 
-        let config_bytes = resp.bytes().await.unwrap();
-        let config_str = std::str::from_utf8(&config_bytes).unwrap();
-        let config: Value = serde_json::from_str(config_str).unwrap();
+        let config: Value = serde_json::from_str(&read_body(resp).await).unwrap();
 
         assert_eq!(counter_name, config["strong-counter"]["name"]);
         assert_eq!(initial_val, config["strong-counter"]["initial-value"]);
@@ -105,7 +103,7 @@ mod counters {
         let resp = run(&counters::get(counter_name)).await;
 
         assert!(resp.status().is_success());
-        assert_eq!("1", resp.bytes().await.unwrap());
+        assert_eq!("1", read_body(resp).await);
     }
 
     #[tokio::test]
@@ -120,7 +118,7 @@ mod counters {
         let resp = run(&counters::get(counter_name)).await;
 
         assert!(resp.status().is_success());
-        assert_eq!("3", resp.bytes().await.unwrap());
+        assert_eq!("3", read_body(resp).await);
     }
 
     #[tokio::test]
@@ -136,7 +134,7 @@ mod counters {
         let resp = run(&counters::get(counter_name)).await;
 
         assert!(resp.status().is_success());
-        assert_eq!((initial_val - 1).to_string(), resp.bytes().await.unwrap());
+        assert_eq!((initial_val - 1).to_string(), read_body(resp).await);
     }
 
     #[tokio::test]
@@ -153,7 +151,7 @@ mod counters {
         let resp = run(&counters::get(counter_name)).await;
 
         assert!(resp.status().is_success());
-        assert_eq!(initial_val.to_string(), resp.bytes().await.unwrap());
+        assert_eq!(initial_val.to_string(), read_body(resp).await);
     }
 
     #[tokio::test]
@@ -180,16 +178,16 @@ mod counters {
         let _ = run(&counters::create_strong(counter_name).with_value(1)).await;
 
         let resp = run(&counters::compare_and_set(counter_name, 0, 2)).await;
-        assert_eq!("false", resp.bytes().await.unwrap());
+        assert_eq!("false", read_body(resp).await);
         let resp = run(&counters::get(counter_name)).await;
         assert!(resp.status().is_success());
-        assert_eq!("1", resp.bytes().await.unwrap());
+        assert_eq!("1", read_body(resp).await);
 
         let resp = run(&counters::compare_and_set(counter_name, 1, 2)).await;
-        assert_eq!("true", resp.bytes().await.unwrap());
+        assert_eq!("true", read_body(resp).await);
         let resp = run(&counters::get(counter_name)).await;
         assert!(resp.status().is_success());
-        assert_eq!("2", resp.bytes().await.unwrap());
+        assert_eq!("2", read_body(resp).await);
     }
 
     #[tokio::test]
@@ -204,12 +202,12 @@ mod counters {
         let _ = run(&counters::compare_and_swap(counter_name, 0, 2)).await;
         let resp = run(&counters::get(counter_name)).await;
         assert!(resp.status().is_success());
-        assert_eq!("1", resp.bytes().await.unwrap());
+        assert_eq!("1", read_body(resp).await);
 
         let _ = run(&counters::compare_and_swap(counter_name, 1, 2)).await;
         let resp = run(&counters::get(counter_name)).await;
         assert!(resp.status().is_success());
-        assert_eq!("2", resp.bytes().await.unwrap());
+        assert_eq!("2", read_body(resp).await);
     }
 
     #[tokio::test]
@@ -238,8 +236,6 @@ mod counters {
     }
 
     async fn counter_names_from_list_resp(response: Response) -> HashSet<String> {
-        let counter_bytes = response.bytes().await.unwrap();
-        let counters_string = std::str::from_utf8(&counter_bytes).unwrap();
-        serde_json::from_str(counters_string).unwrap()
+        serde_json::from_str(&read_body(response).await).unwrap()
     }
 }

--- a/tests/entries.rs
+++ b/tests/entries.rs
@@ -2,11 +2,10 @@ mod helpers;
 
 #[cfg(test)]
 mod entries {
-    use crate::helpers::run;
+    use crate::helpers::{read_body, run};
     use http::StatusCode;
     use infinispan::request::caches;
     use infinispan::request::entries;
-    use reqwest::Response;
     use serial_test::serial;
 
     const TEST_CACHE_NAME: &str = "test_cache";
@@ -36,7 +35,7 @@ mod entries {
             run(&entries::create(TEST_CACHE_NAME, entry_name).with_value(entry_value.into())).await;
         let resp = run(&entries::get(TEST_CACHE_NAME, entry_name)).await;
 
-        assert_eq!(entry_value, entry_value_from_resp(resp).await);
+        assert_eq!(entry_value, read_body(resp).await);
     }
 
     #[tokio::test]
@@ -72,7 +71,7 @@ mod entries {
         let _ = run(&entries::update(TEST_CACHE_NAME, entry_name, new_value)).await;
         let resp = run(&entries::get(TEST_CACHE_NAME, entry_name)).await;
 
-        assert_eq!(new_value, entry_value_from_resp(resp).await);
+        assert_eq!(new_value, read_body(resp).await);
     }
 
     #[tokio::test]
@@ -94,9 +93,5 @@ mod entries {
     async fn setup() {
         let _ = run(&caches::delete(TEST_CACHE_NAME)).await;
         let _ = run(&caches::create_local(TEST_CACHE_NAME)).await;
-    }
-
-    async fn entry_value_from_resp(response: Response) -> String {
-        response.text_with_charset("utf-8").await.unwrap()
     }
 }

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -9,3 +9,7 @@ pub fn infinispan_client() -> Infinispan {
 pub async fn run<R: ToHttpRequest>(request: &R) -> Response {
     infinispan_client().run(request).await.unwrap()
 }
+
+pub async fn read_body(response: Response) -> String {
+    response.text_with_charset("utf-8").await.unwrap()
+}


### PR DESCRIPTION
This PR adds some of the operations that were missing for `Cache`: `get`, `get_config`, `keys`, `clear`, `size`, `stats`, and `list`.

With this we already have all the operations documented in https://infinispan.org/docs/11.0.x/titles/rest/rest.html#rest_v2_cache_operations except the ones around indexes and queries.