### PR TITLE
Add support for more cache modes

### DIFF
--- a/src/request/caches/mod.rs
+++ b/src/request/caches/mod.rs
@@ -1,3 +1,6 @@
+pub mod modes;
+
+use crate::request::caches::modes::LocalCache;
 use crate::request::{Method, Request};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -5,41 +8,10 @@ use std::collections::HashMap;
 
 pub(crate) const CACHES_ENDPOINT: &str = "/rest/v2/caches";
 
-const DEFAULT_CONCURRENCY_LEVEL: i32 = 1000;
-const DEFAULT_ACQUIRE_TIMEOUT: i32 = 15000;
-
 #[derive(Serialize, Deserialize)]
 enum Cache {
     #[serde(rename = "local-cache")]
     LocalCache(LocalCache),
-}
-
-#[derive(Serialize, Deserialize)]
-struct LocalCache {
-    locking: Locking,
-    statistics: bool,
-}
-
-#[derive(Serialize, Deserialize)]
-struct Locking {
-    #[serde(rename = "concurrency-level")]
-    concurrency_level: i32,
-    #[serde(rename = "acquire-timeout")]
-    acquire_timeout: i32,
-    striping: bool,
-}
-
-impl Default for LocalCache {
-    fn default() -> Self {
-        Self {
-            locking: Locking {
-                concurrency_level: DEFAULT_CONCURRENCY_LEVEL,
-                acquire_timeout: DEFAULT_ACQUIRE_TIMEOUT,
-                striping: false,
-            },
-            statistics: true,
-        }
-    }
 }
 
 #[derive(Debug)]

--- a/src/request/caches/modes.rs
+++ b/src/request/caches/modes.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_CONCURRENCY_LEVEL: i32 = 1000;
+const DEFAULT_ACQUIRE_TIMEOUT: i32 = 15000;
+
+#[derive(Serialize, Deserialize)]
+pub struct LocalCache {
+    locking: Locking,
+    statistics: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Locking {
+    #[serde(rename = "concurrency-level")]
+    concurrency_level: i32,
+    #[serde(rename = "acquire-timeout")]
+    acquire_timeout: i32,
+    striping: bool,
+}
+
+impl Default for LocalCache {
+    fn default() -> Self {
+        Self {
+            locking: Locking {
+                concurrency_level: DEFAULT_CONCURRENCY_LEVEL,
+                acquire_timeout: DEFAULT_ACQUIRE_TIMEOUT,
+                striping: false,
+            },
+            statistics: true,
+        }
+    }
+}

--- a/src/request/caches/modes.rs
+++ b/src/request/caches/modes.rs
@@ -1,32 +1,144 @@
 use serde::{Deserialize, Serialize};
 
-const DEFAULT_CONCURRENCY_LEVEL: i32 = 1000;
-const DEFAULT_ACQUIRE_TIMEOUT: i32 = 15000;
+const DEFAULT_CONCURRENCY_LEVEL: i32 = 1_000;
+const DEFAULT_ACQUIRE_TIMEOUT: i32 = 15_000;
+const DEFAULT_STATE_TRANSFER_TIMEOUT: i32 = 60_000;
+const DEFAULT_REMOTE_TIMEOUT: i32 = 17_500;
 
-#[derive(Serialize, Deserialize)]
-pub struct LocalCache {
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
+pub struct Local {
     locking: Locking,
     statistics: bool,
 }
 
-#[derive(Serialize, Deserialize)]
+impl Default for Local {
+    fn default() -> Self {
+        Self {
+            locking: Locking::default(),
+            statistics: true,
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Distributed {
+    mode: String,
+    state_transfer: StateTransfer,
+    locking: Locking,
+    statistics: bool,
+}
+
+impl Distributed {
+    pub fn create_async() -> Self {
+        Self {
+            mode: "ASYNC".into(),
+            state_transfer: StateTransfer {
+                timeout: DEFAULT_STATE_TRANSFER_TIMEOUT,
+            },
+            locking: Locking::default(),
+            statistics: true,
+        }
+    }
+
+    pub fn create_sync() -> Self {
+        Self {
+            mode: "SYNC".into(),
+            state_transfer: StateTransfer {
+                timeout: DEFAULT_STATE_TRANSFER_TIMEOUT,
+            },
+            locking: Locking::default(),
+            statistics: true,
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Replicated {
+    mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remote_timeout: Option<i32>,
+    state_transfer: StateTransfer,
+    locking: Locking,
+    statistics: bool,
+}
+
+impl Replicated {
+    pub fn create_async() -> Self {
+        Self {
+            mode: "ASYNC".into(),
+            remote_timeout: None,
+            state_transfer: StateTransfer {
+                timeout: DEFAULT_STATE_TRANSFER_TIMEOUT,
+            },
+            locking: Locking::default(),
+            statistics: true,
+        }
+    }
+
+    pub fn create_sync() -> Self {
+        Self {
+            mode: "SYNC".into(),
+            remote_timeout: Some(DEFAULT_REMOTE_TIMEOUT),
+            state_transfer: StateTransfer {
+                timeout: DEFAULT_STATE_TRANSFER_TIMEOUT,
+            },
+            locking: Locking::default(),
+            statistics: true,
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Invalidation {
+    mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remote_timeout: Option<i32>,
+    locking: Locking,
+    statistics: bool,
+}
+
+impl Invalidation {
+    pub fn create_async() -> Self {
+        Self {
+            mode: "ASYNC".into(),
+            remote_timeout: None,
+            locking: Locking::default(),
+            statistics: true,
+        }
+    }
+
+    pub fn create_sync() -> Self {
+        Self {
+            mode: "SYNC".into(),
+            remote_timeout: Some(DEFAULT_REMOTE_TIMEOUT),
+            locking: Locking::default(),
+            statistics: true,
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 struct Locking {
-    #[serde(rename = "concurrency-level")]
     concurrency_level: i32,
-    #[serde(rename = "acquire-timeout")]
     acquire_timeout: i32,
     striping: bool,
 }
 
-impl Default for LocalCache {
+impl Default for Locking {
     fn default() -> Self {
         Self {
-            locking: Locking {
-                concurrency_level: DEFAULT_CONCURRENCY_LEVEL,
-                acquire_timeout: DEFAULT_ACQUIRE_TIMEOUT,
-                striping: false,
-            },
-            statistics: true,
+            concurrency_level: DEFAULT_CONCURRENCY_LEVEL,
+            acquire_timeout: DEFAULT_ACQUIRE_TIMEOUT,
+            striping: false,
         }
     }
+}
+
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
+struct StateTransfer {
+    timeout: i32,
 }


### PR DESCRIPTION
This PR adds support for the `replicated`, `distributed` and `invalidation` modes. You can read about them here: https://infinispan.org/docs/stable/titles/configuring/configuring.html#cache_modes-configuring

For now, we only allow creating caches with those modes using the default options, the ones shown in the Infinispan UI. At this stage of the project, there's no point in supporting all the options (ref: https://docs.jboss.org/infinispan/12.1/configdocs/infinispan-config-12.1.html and look for "distributed-cache" for example).