### PR TITLE
Update dependencies to use Tokio 1 and require edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["api-bindings"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = "0.10"
+reqwest = "0.11"
 http = "0.2.3"
 base64 = "0.13.0"
 urlencoding = "2"
@@ -22,5 +22,5 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["rt-core", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 serial_test = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["api-bindings"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = "0.10.10"
+reqwest = "0.10"
 http = "0.2.3"
 base64 = "0.13.0"
-urlencoding = "1.1.1"
+urlencoding = "2"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 name = "infinispan"
 version = "0.2.0"
 description = "Rust client for the Infinispan REST API"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,10 @@ name = "infinispan"
 version = "0.2.0"
 description = "Rust client for the Infinispan REST API"
 license = "Apache-2.0"
-authors = ["Alex Martinez Ruiz <alex@flawedcode.org>"]
+authors = [
+    "David Ortiz <z.david.ortiz@gmail.com>",
+    "Alejandro Martinez Ruiz <alex@flawedcode.org>",
+]
 repository = "https://github.com/kuadrant/infinispan-rs"
 readme = "README.md"
 keywords = ["client", "api", "infinispan", "jboss", "datagrid"]
@@ -14,12 +17,12 @@ categories = ["api-bindings"]
 
 [dependencies]
 reqwest = "0.11"
-http = "0.2.3"
-base64 = "0.13.0"
+http = "0.2"
+base64 = "0.13"
 urlencoding = "2"
-serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0"
+serde_json = "1"
+serde = { version = "1", features = ["derive"] }
+thiserror = "1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,9 @@
 //! ```
 //!
 
+#![deny(clippy::all, clippy::cargo)]
+#![allow(clippy::multiple_crate_versions)]
+
 use std::convert::TryFrom;
 
 use reqwest::Response;


### PR DESCRIPTION
This PR updates a few dependencies and moves to use edition 2021.

The most important thing here is that we now allow dependents to use Tokio 1.X.