### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 0.3.0 - 2021-12-24
+
+### Changed
+
+- Move to edition 2021.
+([#22](https://github.com/kuadrant/infinispan-rs/pull/22)).
+- Require reqwest 0.11 to use the Tokio 1.X async runtime
+([#22](https://github.com/kuadrant/infinispan-rs/pull/22)).
+
 ## 0.2.0 - 2021-05-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "infinispan"
-version = "0.2.0"
+version = "0.3.0"
 description = "Rust client for the Infinispan REST API"
 license = "Apache-2.0"
 authors = [

--- a/README.md
+++ b/README.md
@@ -9,17 +9,20 @@ infinispan-rs is a Rust client for the [Infinispan REST
 API](https://infinispan.org/docs/stable/titles/rest/rest.html). For now, it
 implements a small part of the API.
 
-- [**Install**](#install)
-- [**Usage**](#usage)
-- [**Development**](#development)
-- [**License**](#license)
+- [infinispan-rs](#infinispan-rs)
+  - [Install](#install)
+  - [Usage](#usage)
+  - [Development](#development)
+    - [Build](#build)
+    - [Run the tests](#run-the-tests)
+  - [License](#license)
 
 ## Install
 
 Add the `infinispan` dependency to your `Cargo.toml`:
 ```toml
 [dependencies]
-infinispan = "0.2"
+infinispan = "0.3"
 ```
 
 ## Usage


### PR DESCRIPTION
This is a breaking release as it bumps the MSRV to edition 2021 and pulls in a new version of Reqwest (and Tokio).